### PR TITLE
utilx: Move GetHostname from ginx to utilx

### DIFF
--- a/ginx/gin.go
+++ b/ginx/gin.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"go.infratographer.com/x/utilx"
 	"go.infratographer.com/x/versionx"
 )
 
@@ -76,12 +77,7 @@ func NewServer(lgr *zap.Logger, cfg Config, version *versionx.Details) Server {
 // This setups logging, requestid, and otel middleware.
 func DefaultEngine(lgr *zap.Logger, f LogFunc) *gin.Engine {
 	tp := otel.GetTracerProvider()
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "unknown"
-	}
-
+	hostname := utilx.GetHostname()
 	engine := gin.New()
 
 	logF := func(c *gin.Context) []zapcore.Field {

--- a/utilx/doc.go
+++ b/utilx/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2022 The Infratographer Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package utilx provides a collection of utility functions and types that are
+// used throughout the project.
+package utilx

--- a/utilx/hostname.go
+++ b/utilx/hostname.go
@@ -1,0 +1,40 @@
+// Copyright 2022 The Infratographer Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utilx
+
+import "os"
+
+const (
+	// HostnameEnvVar is the environment variable that is used to get the hostname.
+	HostnameEnvVar = "NODE_NAME"
+)
+
+// GetHostname returns the hostname of the machine.
+// In order to address cases where the UTS namespace is not shared, we will
+// first check for the NODE_NAME environment variable. If that is not set, we
+// will fallback to the hostname of the machine. Finally, if that is not set,
+// we will return "unknown".
+func GetHostname() string {
+	if os.Getenv(HostnameEnvVar) != "" {
+		return os.Getenv("NODE_NAME")
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+
+	return hostname
+}


### PR DESCRIPTION
This introduces a new package called `utilx` which is meant for
general-purpose small utilities that others can leverage.

The first function introduced to this package is `GetHostname` which
does as its name says. However, it also added the small addition of
leveraging a `NODE_NAME` environment variable which takes precedence and
can be used to set the hostname wherever it's needed. The intended
use-case is for environments where the UTS namespace is not shared and
one cannot easily get a relevant hostname (e.g. a container).

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
