### PR TITLE
echox: add helper functions

### DIFF
--- a/echox/config.go
+++ b/echox/config.go
@@ -43,3 +43,11 @@ func MustViperFlags(v *viper.Viper, flags *pflag.FlagSet, defaultListen string) 
 	flags.Duration("shutdown-grace-period", DefaultServerShutdownTimeout, "server shutdown grace period")
 	viperx.MustBindFlag(v, "server.shutdown-grace-period", flags.Lookup("shutdown-grace-period"))
 }
+
+// ConfigFromViper builds a new Config from viper.
+func ConfigFromViper(v *viper.Viper) Config {
+	return Config{
+		Listen:              v.GetString("server.listen"),
+		ShutdownGracePeriod: v.GetDuration("server.shutdown-grace-period"),
+	}
+}


### PR DESCRIPTION
This adds two helper functions.

`SkipDefaultEndpoints` which implements echo's `middleware.Skipper` interface. Allowing for easy use to skip the default echox endpoints (`/version`, `/livez`, `/readyz`, `/metrics`) in any additional middleware.

`ConfigFromViper` simplifies creating a new `echox.Config` from the provided viper. This allows for easier initialization of `echox.Server` by calling `echox.NewServer(logger, echox.ConfigFromViper(v), version)` and allows for future feature additions to be added easily.