### PR TITLE
echox: simplify config, add middleware.

### DIFF
--- a/echox/config.go
+++ b/echox/config.go
@@ -17,6 +17,7 @@ package echox
 import (
 	"time"
 
+	"github.com/labstack/echo/v4"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -42,6 +43,9 @@ type Config struct {
 
 	// TrustedProxies defines the allowed ip / network ranges to trust a proxy from.
 	TrustedProxies []string
+
+	// Middleware includes the provided middleware when echo is initialized.
+	Middleware []echo.MiddlewareFunc
 }
 
 // withDefaults returns a new config with defaults set if not already defined.
@@ -81,6 +85,13 @@ func (c Config) WithShutdownGracePeriod(period time.Duration) Config {
 // WithTrustedProxies defines the allowed ip / network ranges to trust a proxy from.
 func (c Config) WithTrustedProxies(trust ...string) Config {
 	c.TrustedProxies = append(c.TrustedProxies, trust...)
+
+	return c
+}
+
+// WithMiddleware includes the provided middleware when echo is initialized.
+func (c Config) WithMiddleware(mdw ...echo.MiddlewareFunc) Config {
+	c.Middleware = append(c.Middleware, mdw...)
 
 	return c
 }

--- a/echox/config.go
+++ b/echox/config.go
@@ -31,10 +31,58 @@ var (
 
 // Config is used to configure a new ginx server
 type Config struct {
-	Debug               bool
-	Listen              string
+	// Debug enables echo's Debug option.
+	Debug bool
+
+	// Listen sets the listen address to serve the echo server on.
+	Listen string
+
+	// ShutdownGracePeriod sets the grace period for in flight requests before shutting down.
 	ShutdownGracePeriod time.Duration
-	TrustedProxies      []string
+
+	// TrustedProxies defines the allowed ip / network ranges to trust a proxy from.
+	TrustedProxies []string
+}
+
+// withDefaults returns a new config with defaults set if not already defined.
+func (c Config) withDefaults() Config {
+	if c.Listen == "" {
+		c.Listen = ":8080"
+	}
+
+	if c.ShutdownGracePeriod <= 0 {
+		c.ShutdownGracePeriod = DefaultServerShutdownTimeout
+	}
+
+	return c
+}
+
+// WithDebug enables echo's Debug option.
+func (c Config) WithDebug(debug bool) Config {
+	c.Debug = debug
+
+	return c
+}
+
+// WithListen sets the listen address to serve the echo server on.
+func (c Config) WithListen(listen string) Config {
+	c.Listen = listen
+
+	return c
+}
+
+// WithShutdownGracePeriod sets the grace period for in flight requests before shutting down.
+func (c Config) WithShutdownGracePeriod(period time.Duration) Config {
+	c.ShutdownGracePeriod = period
+
+	return c
+}
+
+// WithTrustedProxies defines the allowed ip / network ranges to trust a proxy from.
+func (c Config) WithTrustedProxies(trust ...string) Config {
+	c.TrustedProxies = append(c.TrustedProxies, trust...)
+
+	return c
 }
 
 // MustViperFlags returns the cobra flags and wires them up with viper to prevent code duplication

--- a/echox/echo.go
+++ b/echox/echo.go
@@ -66,10 +66,7 @@ type Server struct {
 
 // NewServer will return an opinionated echo server for processing API requests.
 func NewServer(logger *zap.Logger, cfg Config, version *versionx.Details) (*Server, error) {
-	shutdownTimeout := cfg.ShutdownGracePeriod
-	if shutdownTimeout == 0 {
-		shutdownTimeout = DefaultServerShutdownTimeout
-	}
+	cfg = cfg.withDefaults()
 
 	trustedProxies, err := parseIPNets(cfg.TrustedProxies)
 	if err != nil {
@@ -82,7 +79,7 @@ func NewServer(logger *zap.Logger, cfg Config, version *versionx.Details) (*Serv
 		logger:          logger.Named("echox"),
 		version:         version,
 		readinessChecks: map[string]CheckFunc{},
-		shutdownTimeout: shutdownTimeout,
+		shutdownTimeout: cfg.ShutdownGracePeriod,
 		trustedProxies:  trustedProxies,
 	}, nil
 }

--- a/echox/echo_test.go
+++ b/echox/echo_test.go
@@ -126,6 +126,7 @@ func TestNewServer(t *testing.T) {
 			Config{},
 			&Server{
 				logger:          zap.NewNop().Named("echox"),
+				listen:          ":8080",
 				readinessChecks: map[string]CheckFunc{},
 				shutdownTimeout: DefaultServerShutdownTimeout,
 			},
@@ -145,6 +146,7 @@ func TestNewServer(t *testing.T) {
 			},
 			&Server{
 				logger:          zap.NewNop().Named("echox"),
+				listen:          ":8080",
 				readinessChecks: map[string]CheckFunc{},
 				shutdownTimeout: DefaultServerShutdownTimeout,
 				trustedProxies: []*net.IPNet{


### PR DESCRIPTION
With the new config helpers and the new middleware option. A user may `echox.ConfigFromViper(v).WithMiddleware(mdw...)` to simplify configuration.