### PR TITLE
echox: fix race condition in test

### DIFF
--- a/echox/echo_test.go
+++ b/echox/echo_test.go
@@ -516,6 +516,8 @@ func TestServe(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 


### PR DESCRIPTION
This resolves a race condition when a request to the test http server is handled after the test has completed.

The range writes to `tc` but the request handler reads from `tc` causing the race condition.

Solution is to recapture the variable inside the loop.