### PR TITLE
Make PageInfo as shareable since all subgraphs define it when using federation

### DIFF
--- a/entx/generator.go
+++ b/entx/generator.go
@@ -24,7 +24,7 @@ type ExtensionOption func(*Extension) error
 func WithFederation() ExtensionOption {
 	return func(ex *Extension) error {
 		ex.templates = append(ex.templates, FederationTemplate)
-		ex.gqlSchemaHooks = append(ex.gqlSchemaHooks, removeNodeGoModel, removeNodeQueries)
+		ex.gqlSchemaHooks = append(ex.gqlSchemaHooks, removeNodeGoModel, removeNodeQueries, setPageInfoShareable)
 
 		return nil
 	}

--- a/entx/gql_hooks.go
+++ b/entx/gql_hooks.go
@@ -55,6 +55,17 @@ var (
 		return nil
 	}
 
+	setPageInfoShareable = func(g *gen.Graph, s *ast.Schema) error {
+		q, ok := s.Types["PageInfo"]
+		if !ok {
+			return nil
+		}
+
+		q.Directives = append(q.Directives, &ast.Directive{Name: "shareable"})
+
+		return nil
+	}
+
 	addJSONScalar = func(g *gen.Graph, s *ast.Schema) error {
 		s.Types["JSON"] = &ast.Definition{
 			Kind:        ast.Scalar,


### PR DESCRIPTION
Switching to federation spec 2.3 we need to set types that are defined in multiple subgraphs as `@sharable`. 