### PR TITLE
Add watermillzap; Add test to verify unknown-actor behavior;

### DIFF
--- a/events/nats.go
+++ b/events/nats.go
@@ -1,16 +1,17 @@
 package events
 
 import (
-	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill-nats/v2/pkg/nats"
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/garsue/watermillzap"
 	nc "github.com/nats-io/nats.go"
+	"go.uber.org/zap"
 )
 
 var natsMarshaler = &nats.JSONMarshaler{}
 
-func newNATSPublisher(cfg PublisherConfig) (message.Publisher, error) {
-	logger := watermill.NewStdLogger(false, false)
+func newNATSPublisher(cfg PublisherConfig, logger *zap.SugaredLogger) (message.Publisher, error) {
+	logAdapter := watermillzap.NewLogger(logger.Desugar())
 
 	options := []nc.Option{
 		nc.Timeout(cfg.Timeout),
@@ -40,12 +41,12 @@ func newNATSPublisher(cfg PublisherConfig) (message.Publisher, error) {
 			Marshaler:   natsMarshaler,
 			JetStream:   jsConfig,
 		},
-		logger,
+		logAdapter,
 	)
 }
 
-func newNATSSubscriber(cfg SubscriberConfig) (message.Subscriber, error) {
-	logger := watermill.NewStdLogger(false, false)
+func newNATSSubscriber(cfg SubscriberConfig, logger *zap.SugaredLogger) (message.Subscriber, error) {
+	logAdapter := watermillzap.NewLogger(logger.Desugar())
 
 	options := []nc.Option{
 		nc.Timeout(cfg.Timeout),
@@ -69,7 +70,7 @@ func newNATSSubscriber(cfg SubscriberConfig) (message.Subscriber, error) {
 			JetStream:        jsConfig,
 			QueueGroupPrefix: cfg.QueueGroup,
 		},
-		logger,
+		logAdapter,
 	)
 
 	return sub, err

--- a/events/nats_test.go
+++ b/events/nats_test.go
@@ -37,6 +37,12 @@ func TestNatsPublishAndSubscribe(t *testing.T) {
 	err = publisher.PublishChange(ctx, "test", change2)
 	require.NoError(t, err)
 
+	change3 := testCreateChange()
+	change3.ActorID = ""
+
+	err = publisher.PublishChange(ctx, "test", change3)
+	require.NoError(t, err)
+
 	sub, err := events.NewSubscriber(subCfg)
 	require.NoError(t, err)
 
@@ -57,6 +63,15 @@ func TestNatsPublishAndSubscribe(t *testing.T) {
 	chgMsg, err = events.UnmarshalChangeMessage(receivedMsg.Payload)
 	require.NoError(t, err)
 	assert.EqualValues(t, change2, chgMsg)
+	assert.True(t, receivedMsg.Ack())
+
+	receivedMsg, err = getSingleMessage(messages, time.Second*1)
+	require.NoError(t, err)
+
+	chgMsg, err = events.UnmarshalChangeMessage(receivedMsg.Payload)
+	require.NoError(t, err)
+	assert.NotEqualValues(t, change3, chgMsg)
+	assert.Equal(t, "unknown-actor", chgMsg.ActorID.String())
 	assert.True(t, receivedMsg.Ack())
 }
 

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v23.0.5+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/garsue/watermillzap v1.2.0 // indirect
 	github.com/go-openapi/inflect v0.19.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/garsue/watermillzap v1.2.0 h1:IA0zGb5b7mIGLXN9P2/6CmP5+f7Qgb00BdL2VCAk2SA=
+github.com/garsue/watermillzap v1.2.0/go.mod h1:uo3SDSGYaw6RBzUx9jcHMYqypOTqlQ4/vz+8r1olRto=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/requestid v0.0.6 h1:mGcxTnHQ45F6QU5HQRgQUDsAfHprD3P7g2uZ4cSZo9o=
 github.com/gin-contrib/requestid v0.0.6/go.mod h1:9i4vKATX/CdggbkY252dPVasgVucy/ggBeELXuQztm4=


### PR DESCRIPTION
# Summary

* By default watermill uses `"log"` which is a blocking logger on a mutex. Watermill has an interface for logging that `watermillzap` helps with
*  Preserves API with previous release but using a `zap.NewNop()` logger by default. 
* Extends tests a pinch