### PR TITLE
Small improvements to events package for nats publishing/subscription

### DIFF
--- a/events/config.go
+++ b/events/config.go
@@ -45,8 +45,8 @@ type SubscriberConfig struct {
 
 // NATSConfig handles reading in all pubsub values specific to NATS
 type NATSConfig struct {
-	Token     string `mapstructure:"token"`
-	CredsFile string `mapstructure:"credsFile"`
+	Token      string `mapstructure:"token"`
+	CredsFile  string `mapstructure:"credsFile"`
 }
 
 // MustViperFlagsForPublisher returns the cobra flags and viper config for an event publisher
@@ -77,4 +77,24 @@ func MustViperFlagsForSubscriber(v *viper.Viper, flags *pflag.FlagSet) {
 	v.MustBindEnv("events.subscriber.nats.credsFile")
 
 	v.SetDefault("events.subscriber.timeout", defaultTimeout)
+}
+
+// SubscriberConfigFromViper builds a new SubscriberConfig from viper.
+func SubscriberConfigFromViper(v *viper.Viper) SubscriberConfig {
+	return SubscriberConfig{
+		URL:        v.GetString("events.subscriber.url"),
+		Timeout:    v.GetDuration("events.subscriber.timeout"),
+		Prefix:     v.GetString("events.subscriber.prefix"),
+		QueueGroup: v.GetString("events.subscriber.queueGroup"),
+	}
+}
+
+// PublisherConfigFromViper builds a new PublisherConfig from viper.
+func PublisherConfigFromViper(v *viper.Viper) PublisherConfig {
+	return PublisherConfig{
+		URL:     v.GetString("events.publisher.url"),
+		Timeout: v.GetDuration("events.publisher.timeout"),
+		Prefix:  v.GetString("events.publisher.prefix"),
+		Source:  v.GetString("events.publisher.source"),
+	}
 }

--- a/events/message.go
+++ b/events/message.go
@@ -11,6 +11,9 @@ import (
 // ChangeType represents the possible event types for a ChangeMessage
 type ChangeType string
 
+// EventType represents the possible event types for an EventMessage
+type EventType string
+
 var (
 	// CreateChangeType provides the event type for create events
 	CreateChangeType ChangeType = "create"
@@ -18,6 +21,13 @@ var (
 	UpdateChangeType ChangeType = "update"
 	// DeleteChangeType provides the event type for delete events
 	DeleteChangeType ChangeType = "delete"
+
+	// CreateEventType provides the event type for create events
+	CreateEventType EventType = "create"
+	// UpdateEventType provides the event type for update events
+	UpdateEventType EventType = "update"
+	// DeleteEventType provides the event type for delete events
+	DeleteEventType EventType = "delete"
 )
 
 // FieldChange represents a single field that was changed in a changeset and is used to map fields to the old and new values

--- a/events/publisher.go
+++ b/events/publisher.go
@@ -85,12 +85,12 @@ func (p *Publisher) PublishChange(ctx context.Context, subjectType string, chang
 }
 
 // PublishEvent will publish an EventMessage to the proper topic for that event
-func (p *Publisher) PublishEvent(_ context.Context, event EventMessage) error {
+func (p *Publisher) PublishEvent(_ context.Context, subjectType string, event EventMessage) error {
 	if event.EventType == "" {
 		return ErrMissingEventType
 	}
 
-	topic := strings.Join([]string{p.prefix, "events", event.EventType}, ".")
+	topic := strings.Join([]string{p.prefix, "events", event.EventType, subjectType}, ".")
 
 	event.Source = p.source
 


### PR DESCRIPTION
- Adds small helps for setting up your subscriber/publisher configs with NATS
- Adds missing definitions for event message event types
- Adjusts PublishEventMessage to publish to similar subject name as we expect with PublishChangeMessage
- Adjusts NATS to use `DurableCalculator` instead of `QueuePrefix` per NATS/watermill recommendations
  - This will now use a small function to calculate the name of the consumer instead of just using the queue/topic name. This was causing issues with overlapping consumer names for multiple instances/apps that were listening on the same subject. This now essentially will take the queue name that is provided by the application (`--event-subscriber-queuegroup`) and then concatenates it with a hex encoded string of the full topic name (prefix+calculated topic) to give us a consumer name that is easy to calculate.

* Using the DurablePrefix gives us the added benefit of when a member of the queue group drops or rejoins, it will be able to pick back up where the last consume left off vs potentially starting fresh if all members of that group had previously dropped.