### PR TITLE
Add tracing to events package, deprecate TraceID/SpanID

### DIFF
--- a/events/message.go
+++ b/events/message.go
@@ -66,9 +66,13 @@ type ChangeMessage struct {
 	Source string `json:"source"`
 	// Timestamp is the time representing when the message was created
 	Timestamp time.Time `json:"timestamp"`
+	// TraceContext is a map of values used for OpenTelemetry context propagation.
+	TraceContext map[string]string `json:"traceContext"`
 	// TraceID is the ID of the trace for this event
+	// Deprecated: Use TraceContext with OpenTelemetry context propagation instead.
 	TraceID string `json:"traceID"`
 	// SpanID is the ID of the span that additional traces should based off of
+	// Deprecated: Use TraceContext with OpenTelemetry context propagation instead.
 	SpanID string `json:"spanID"`
 	// SubjectFields is a map of the fields on the subject
 	SubjectFields map[string]string `json:"subjectFields"`
@@ -91,9 +95,13 @@ type EventMessage struct {
 	Source string `json:"source"`
 	// Timestamp is the time representing when the message was created
 	Timestamp time.Time `json:"timestamp"`
+	// TraceContext is a map of values used for OpenTelemetry context propagation.
+	TraceContext map[string]string `json:"traceContext"`
 	// TraceID is the ID of the trace for this event
+	// Deprecated: Use TraceContext with OpenTelemetry context propagation instead.
 	TraceID string `json:"traceID"`
 	// SpanID is the ID of the span that additional traces should based off of
+	// Deprecated: Use TraceContext with OpenTelemetry context propagation instead.
 	SpanID string `json:"spanID"`
 	// Data is a field to store any information that may be important to include about the event
 	Data map[string]interface{} `json:"data"`

--- a/events/message.go
+++ b/events/message.go
@@ -123,9 +123,13 @@ type AuthRelationshipRequest struct {
 	ConditionName string `json:"conditionName"`
 	// ConditionValues are the condition values to be used on the condition check. (Optional)
 	ConditionValues map[string]interface{} `json:"conditionValue"`
+	// TraceContext is a map of values used for OpenTelemetry context propagation.
+	TraceContext map[string]string `json:"traceContext"`
 	// TraceID is the ID of the trace for this event
+	// Deprecated: Use TraceContext with OpenTelemetry context propagation instead.
 	TraceID string `json:"traceID"`
 	// SpanID is the ID of the span that additional traces should based off of
+	// Deprecated: Use TraceContext with OpenTelemetry context propagation instead.
 	SpanID string `json:"spanID"`
 }
 
@@ -134,9 +138,13 @@ type AuthRelationshipRequest struct {
 type AuthRelationshipResponse struct {
 	// Errors contains any errors, if empty the request was successful
 	Errors []error `json:"errors"`
+	// TraceContext is a map of values used for OpenTelemetry context propagation.
+	TraceContext map[string]string `json:"traceContext"`
 	// TraceID is the ID of the trace for this event
+	// Deprecated: Use TraceContext with OpenTelemetry context propagation instead.
 	TraceID string `json:"traceID"`
 	// SpanID is the ID of the span that additional traces should based off of
+	// Deprecated: Use TraceContext with OpenTelemetry context propagation instead.
 	SpanID string `json:"spanID"`
 }
 

--- a/events/nats_test.go
+++ b/events/nats_test.go
@@ -209,6 +209,7 @@ func testChange(eventType string) events.ChangeMessage {
 				CurrentValue:  string(js),
 			},
 		},
+		TraceContext: map[string]string{},
 	}
 }
 

--- a/events/publisher.go
+++ b/events/publisher.go
@@ -101,7 +101,7 @@ func (p *Publisher) PublishChange(ctx context.Context, subjectType string, chang
 			),
 			attribute.String(
 				"events.source",
-				p.source,
+				change.Source,
 			),
 		),
 	)
@@ -195,7 +195,7 @@ func (p *Publisher) PublishEvent(ctx context.Context, subjectType string, event 
 			),
 			attribute.String(
 				"events.source",
-				p.source,
+				event.Source,
 			),
 		),
 	)

--- a/events/subscriber.go
+++ b/events/subscriber.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	"go.uber.org/zap"
 )
 
@@ -76,4 +78,18 @@ func (s *Subscriber) SubscribeEvents(ctx context.Context, topic string) (<-chan 
 // Close will close the subscriber
 func (s *Subscriber) Close() error {
 	return s.subscriber.Close()
+}
+
+// TraceContextFromChangeMessage creates a new OpenTelemetry context from the given ChangeMessage.
+func TraceContextFromChangeMessage(ctx context.Context, msg ChangeMessage) context.Context {
+	tp := otel.GetTextMapPropagator()
+
+	return tp.Extract(ctx, propagation.MapCarrier(msg.TraceContext))
+}
+
+// TraceContextFromEventMessage creates a new OpenTelemetry context from the given ChangeMessage.
+func TraceContextFromEventMessage(ctx context.Context, msg EventMessage) context.Context {
+	tp := otel.GetTextMapPropagator()
+
+	return tp.Extract(ctx, propagation.MapCarrier(msg.TraceContext))
 }

--- a/testing/eventtools/nats_test.go
+++ b/testing/eventtools/nats_test.go
@@ -111,6 +111,7 @@ func testChange(eventType string) events.ChangeMessage {
 				CurrentValue:  string(js),
 			},
 		},
+		TraceContext: map[string]string{},
 	}
 }
 


### PR DESCRIPTION
This PR adds tracing using a new field, TraceContext, in ChangeMessage and EventMessage. While we could stick with TraceID and SpanID (and those fields still exist in the message and will be marshaled/unmarshaled), there are other OpenTelemetry features like the Baggage API and W3C traceparent/tracestate values that we can leverage using TraceContext instead. Moving to this allows for a tighter integration with OpenTelemetry's Go SDK as well and makes it easier for other services using the events package to add observability to their event systems.