### PR TITLE
nats: change default delivery policy

### DIFF
--- a/events/nats_errors.go
+++ b/events/nats_errors.go
@@ -7,7 +7,7 @@ var (
 	ErrNATSInvalidAuthConfiguration = errors.New("invalid nats confinguration, both token and creds file are specified")
 
 	// ErrNATSInvalidDeliveryPolicy is returned when an incorrect delivery policy is provided.
-	ErrNATSInvalidDeliveryPolicy = errors.New("invalid delivery policy")
+	ErrNATSInvalidDeliveryPolicy = errors.New("invalid delivery policy, expected all|last|last-per-subject|new|start-sequence|start-time")
 
 	// ErrNATSMessageNoReplySubject is returned when calling ReplyAuthRelationshipRequest when the request has no reply subject defined.
 	ErrNATSMessageNoReplySubject = errors.New("unable to reply to auth relationship request, no reply subject specified")


### PR DESCRIPTION
Previously the default was to set the Delivery Policy to all, however if connecting to a consumer which already existed with a different delivery policy, nats returns an error for a mismatch.

This change removes the default when no delivery policy is defined, to not specify any delivery policy.

Additionally, I've added the remaining delivery policy options.