### PR TITLE
use nats source as connection label

### DIFF
--- a/events/nats_config.go
+++ b/events/nats_config.go
@@ -134,6 +134,10 @@ func (c NATSConfig) WithDefaults() NATSConfig {
 		c.connectOptions = append(c.connectOptions, nats.UserCredentials(c.CredsFile))
 	}
 
+	if c.Source != "" {
+		c.connectOptions = append(c.connectOptions, nats.Name(c.Source))
+	}
+
 	return c
 }
 


### PR DESCRIPTION
Nats supports providing a connection a name.
To help with troubleshooting we should set this name so it's clear which connections are from which service.

We already have the Source field which defines the source in the messages, so we can simply reuse this variable and add a conneciton option to set the name.