### PR TITLE
Fix QueueSubscribeSync and backoff errors

### DIFF
--- a/events/nats_subscribe.go
+++ b/events/nats_subscribe.go
@@ -24,9 +24,11 @@ func (c *NATSConnection) coreSubscribe(ctx context.Context, subject string) (<-c
 	go func() {
 		for {
 			if err := c.nextMessage(ctx, sub, msgCh); err != nil {
-				if !errors.Is(err, context.DeadlineExceeded) {
-					logger.Errorw("error fetching messages", "error", err)
+				if errors.Is(err, context.DeadlineExceeded) {
+					continue
 				}
+
+				logger.Errorw("error fetching messages", "error", err)
 
 				select {
 				case <-ctx.Done():
@@ -70,9 +72,11 @@ func (c *NATSConnection) jsSubscribe(ctx context.Context, subject string) (<-cha
 	go func() {
 		for {
 			if err := c.fetchMessages(ctx, sub, msgCh); err != nil {
-				if !errors.Is(err, context.DeadlineExceeded) {
-					logger.Errorw("error fetching messages", "error", err)
+				if errors.Is(err, context.DeadlineExceeded) {
+					continue
 				}
+
+				logger.Errorw("error fetching messages", "error", err)
 
 				select {
 				case <-ctx.Done():

--- a/events/nats_subscribe.go
+++ b/events/nats_subscribe.go
@@ -14,7 +14,7 @@ func (c *NATSConnection) coreSubscribe(ctx context.Context, subject string) (<-c
 		"nats.subject", subject,
 	)
 
-	sub, err := c.conn.QueueSubscribeSync(subject, c.cfg.QueueGroup)
+	sub, err := c.conn.QueueSubscribeSync(subject, NATSConsumerDurableName(c.cfg.QueueGroup, subject))
 	if err != nil {
 		return nil, err
 	}

--- a/events/nats_subscribe.go
+++ b/events/nats_subscribe.go
@@ -14,7 +14,7 @@ func (c *NATSConnection) coreSubscribe(ctx context.Context, subject string) (<-c
 		"nats.subject", subject,
 	)
 
-	sub, err := c.conn.SubscribeSync(subject)
+	sub, err := c.conn.QueueSubscribeSync(subject, c.cfg.QueueGroup)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Core NATS subscriptions were incorrectly using `SubscribeSync` instead of `QueueSubscribeSync` and both core and JetStream subscriptions were waiting for the backoff period (default 5 seconds) for all iterations of the worker loop, not just error conditions. This PR fixes both issues.