### PR TITLE
Add commonly needed message getters

### DIFF
--- a/events/message.go
+++ b/events/message.go
@@ -152,6 +152,16 @@ func (m EventMessage) GetAddSubjects() []gidx.PrefixedID {
 	return m.AdditionalSubjectIDs
 }
 
+// GetEventType returns the event type of the message
+func (m ChangeMessage) GetEventType() string {
+	return m.EventType
+}
+
+// GetEventType returns the event type of the message
+func (m EventMessage) GetEventType() string {
+	return m.EventType
+}
+
 // Validate ensures the message has all the required fields.
 func (m ChangeMessage) Validate() error {
 	var err error

--- a/events/message.go
+++ b/events/message.go
@@ -132,6 +132,26 @@ func (m ChangeMessage) GetTraceContext(ctx context.Context) context.Context {
 	return tp.Extract(ctx, propagation.MapCarrier(m.TraceContext))
 }
 
+// GetSubject returns the subject of the message
+func (m ChangeMessage) GetSubject() gidx.PrefixedID {
+	return m.SubjectID
+}
+
+// GetSubject returns the subject of the message
+func (m EventMessage) GetSubject() gidx.PrefixedID {
+	return m.SubjectID
+}
+
+// GetAddSubjects returns the additional subjects of the message
+func (m ChangeMessage) GetAddSubjects() []gidx.PrefixedID {
+	return m.AdditionalSubjectIDs
+}
+
+// GetAddSubjects returns the additional subjects of the message
+func (m EventMessage) GetAddSubjects() []gidx.PrefixedID {
+	return m.AdditionalSubjectIDs
+}
+
 // Validate ensures the message has all the required fields.
 func (m ChangeMessage) Validate() error {
 	var err error


### PR DESCRIPTION
What we've seen is a common usage pattern of having to build generic functions around the usage of Change and Event messages. By adding some commonly used functions to access data from the message, it facilitates a better user experience when building a downstream interface to take advantage of these fields.