### PR TITLE
[events] Support ephemeral consumers

### DIFF
--- a/events/nats_config.go
+++ b/events/nats_config.go
@@ -55,10 +55,6 @@ type NATSConfig struct {
 
 // Configured checks whether the provider has been configured.
 func (c NATSConfig) Configured() bool {
-	if c.QueueGroup == "" {
-		c.logger.Warn("NATS QueueGroup is not set. Subscriptions will not be durable.")
-	}
-
 	return c.URL != ""
 }
 

--- a/events/nats_config.go
+++ b/events/nats_config.go
@@ -55,7 +55,11 @@ type NATSConfig struct {
 
 // Configured checks whether the provider has been configured.
 func (c NATSConfig) Configured() bool {
-	return c.URL != "" || c.QueueGroup != ""
+	if c.QueueGroup == "" {
+		c.logger.Warn("NATS QueueGroup is not set. Subscriptions will not be durable.")
+	}
+
+	return c.URL != ""
 }
 
 // Validate ensures the configuration is valid.

--- a/events/nats_connection.go
+++ b/events/nats_connection.go
@@ -121,6 +121,10 @@ func NewNATSConnection(config NATSConfig, options ...NATSOption) (*NATSConnectio
 		}
 	}
 
+	if config.QueueGroup == "" {
+		nc.logger.Warn("NATS QueueGroup is not set. Subscriptions will not be durable.")
+	}
+
 	conn, err := nats.Connect(config.URL, nc.connectOptions...)
 	if err != nil {
 		return nil, err

--- a/events/nats_connection.go
+++ b/events/nats_connection.go
@@ -143,7 +143,12 @@ func NewNATSConnection(config NATSConfig, options ...NATSOption) (*NATSConnectio
 }
 
 // NATSConsumerDurableName is the generator function to create a new durable consumer name.
+// If queueGroup is empty, an empty durable name is returned to support ephemeral consumers.
 func NATSConsumerDurableName(queueGroup, subject string) string {
+	if queueGroup == "" {
+		return ""
+	}
+
 	hash := md5.Sum([]byte(subject))
 
 	return queueGroup + hex.EncodeToString(hash[:])

--- a/testing/eventtools/nats_test.go
+++ b/testing/eventtools/nats_test.go
@@ -20,14 +20,17 @@ var errTimeout = errors.New("timeout waiting for event")
 func TestNats(t *testing.T) {
 	ctx := context.Background()
 
-	consumerName := events.NATSConsumerDurableName("", eventtools.Prefix+".changes.>")
+	consumerName := events.NATSConsumerDurableName("nats-testing", eventtools.Prefix+".changes.>")
 
 	nats, err := eventtools.NewNatsServer()
 	require.NoError(t, err)
 
 	defer nats.Close()
 
-	conn, err := events.NewNATSConnection(nats.Config.NATS)
+	natsCfg := nats.Config.NATS
+	natsCfg.QueueGroup = "nats-testing"
+
+	conn, err := events.NewNATSConnection(natsCfg)
 	require.NoError(t, err)
 
 	change1 := testCreateChange()


### PR DESCRIPTION
[loadbalancer-manager-haproxy](https://github.com/infratographer/loadbalancer-manager-haproxy) does not have a need for durable message queues, as we want each instance  to consume all messages received related to loadbalancers. 

Currently, we generate a unique durable queue for each manager instance, which eventually puts strain on nats with the number of consumers that can be generated over time. This PR aims to put support for ephemeral consumers back into event subscriptions, if requested, by leaving `QueueGroup` empty in the nats config. 