### PR TITLE
Add annotation to tag an ent field as an additionalSubject

### DIFF
--- a/entx/annotation.go
+++ b/entx/annotation.go
@@ -17,10 +17,12 @@ package entx
 // EventsHookAnnotationName is the value of the annotation when read during ent compilation
 var EventsHookAnnotationName = "INFRA9_EVENTHOOKS"
 
-// EventsHookAnnotation provides a ent.Annotation spec. These shouldn't be set directly, you should use EventsHookAdditionalSubject() and EventsHookSubjectName instead
+// EventsHookAnnotation provides a ent.Annotation spec.
+// These shouldn't be set directly, you should use EventsHookAdditionalSubject(), EventsHookAdditionalSubjectField() and EventsHookSubjectName() instead
 type EventsHookAnnotation struct {
 	SubjectName               string
 	AdditionalSubjectRelation string
+	IsAdditionalSubjectField  bool
 }
 
 // Name implements the ent Annotation interface.
@@ -28,10 +30,17 @@ func (a EventsHookAnnotation) Name() string {
 	return EventsHookAnnotationName
 }
 
-// EventsHookAdditionalSubject marks this field as a field to return as an additional subject
+// EventsHookAdditionalSubject marks this ent field as a field to return as an additional subject relationship
 func EventsHookAdditionalSubject(relation string) *EventsHookAnnotation {
 	return &EventsHookAnnotation{
 		AdditionalSubjectRelation: relation,
+	}
+}
+
+// EventsHookAdditionalSubjectField marks this ent field as a field to return an additional subject in the change event
+func EventsHookAdditionalSubjectField() *EventsHookAnnotation {
+	return &EventsHookAnnotation{
+		IsAdditionalSubjectField: true,
 	}
 }
 

--- a/entx/template/event_hooks.tmpl
+++ b/entx/template/event_hooks.tmpl
@@ -43,7 +43,7 @@
 									{{ $currentValue }} := ""
 									{{ $f.Name }}, ok := m.{{ $f.MutationGet }}()
 									{{- $annotation := $f.Annotations.INFRA9_EVENTHOOKS }}
-									{{- if $annotation.AdditionalSubjectRelation }}
+									{{- if or $annotation.AdditionalSubjectRelation $annotation.IsAdditionalSubjectField }}
 										if !ok && !m.Op().Is(ent.OpCreate) {
 											// since we are doing an update or delete and these fields didn't change, load the "old" value
 											{{ $f.Name }}, err = m.{{ $f.MutationGetOld }}(ctx)
@@ -55,18 +55,22 @@
 											if {{ $f.Name }} != gidx.NullPrefixedID {
 												additionalSubjects = append(additionalSubjects, {{ $f.Name }})
 
+												{{- if $annotation.AdditionalSubjectRelation }}
 												relationships = append(relationships, events.AuthRelationshipRelation{
 													Relation:  "{{ $annotation.AdditionalSubjectRelation }}",
 													SubjectID: {{ $f.Name }},
 												})
+												{{- end }}
 											}
 										{{- else }}
 											additionalSubjects = append(additionalSubjects, {{ $f.Name }})
 
+											{{- if $annotation.AdditionalSubjectRelation }}
 											relationships = append(relationships, events.AuthRelationshipRelation{
 												Relation:  "{{ $annotation.AdditionalSubjectRelation }}",
 												SubjectID: {{ $f.Name }},
 											})
+											{{- end }}
 										{{- end }}
 									{{ end }}
 
@@ -127,7 +131,7 @@
 								return retValue, err
 							}
 
-						if len(relationships) != 0 {
+						if len(relationships) != 0 && m.Op().Is(ent.OpCreate) {
 							if err := permissions.CreateAuthRelationships(ctx, "{{ $nodeAnnotation.SubjectName }}", objID, relationships...); err != nil {
 								return nil, fmt.Errorf("relationship request failed with error: %w", err)
 							}
@@ -162,23 +166,27 @@
 							{{- range $f := $node.Fields }}
 								{{- if not $f.Sensitive }}
 									{{- $annotation := $f.Annotations.INFRA9_EVENTHOOKS }}
-									{{- if $annotation.AdditionalSubjectRelation }}
+									{{- if or $annotation.AdditionalSubjectRelation $annotation.IsAdditionalSubjectField }}
 										{{- if $f.Optional }}
 											if dbObj.{{ $f.MutationGet }} != gidx.NullPrefixedID {
 												additionalSubjects = append(additionalSubjects, dbObj.{{ $f.MutationGet }})
 
+												{{- if $annotation.AdditionalSubjectRelation }}
 												relationships = append(relationships, events.AuthRelationshipRelation{
 													Relation:  "{{ $annotation.AdditionalSubjectRelation }}",
 													SubjectID: dbObj.{{ $f.MutationGet }},
 												})
+												{{- end }}
 											}
 										{{- else }}
 											additionalSubjects = append(additionalSubjects, dbObj.{{ $f.MutationGet }})
 
+											{{- if $annotation.AdditionalSubjectRelation }}
 											relationships = append(relationships, events.AuthRelationshipRelation{
 												Relation:  "{{ $annotation.AdditionalSubjectRelation }}",
 												SubjectID: dbObj.{{ $f.MutationGet }},
 											})
+											{{- end }}
 										{{- end }}
 									{{ end }}
 								{{ end }}


### PR DESCRIPTION
Prior to the events re-work, we were able to tag an annotation on an ent schema field to be included as an `additionalSubject` in the event message. 

Proposing to bring that back, so any api in the infratographer ecosystem does not have to manually manage additional subjects in the generated event hooks. 