### PR TITLE
Satisfy the golang compiler.

### DIFF
--- a/entx/template/event_hooks.tmpl
+++ b/entx/template/event_hooks.tmpl
@@ -163,6 +163,9 @@
 								return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
 							}
 
+							// Satisfies the go error: dbObj declared and not used
+							if dbObj != nil { }
+
 							{{- range $f := $node.Fields }}
 								{{- if not $f.Sensitive }}
 									{{- $annotation := $f.Annotations.INFRA9_EVENTHOOKS }}


### PR DESCRIPTION
This satisfies the errors generated by the event hook generators (line numbers may vary :safety_pin:)

```
internal/ent/generated/eventhooks/hooks.go:287:6: dbObj declared and not used
internal/ent/generated/eventhooks/hooks.go:467:6: dbObj declared and not used
internal/ent/generated/eventhooks/hooks.go:779:6: dbObj declared and not used
internal/ent/generated/eventhooks/hooks.go:1069:6: dbObj declared and not used
internal/ent/generated/eventhooks/hooks.go:1579:6: dbObj declared and not used
```