### PR TITLE
make the committee default owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-* @nicolerenee @sfunkhouser
+* @infratographer/the_committee
 
 # All events related packages will be owned by sig-events
 events/ @infratographer/sig-events


### PR DESCRIPTION
This updates the default owners to use a team which can maintained better.