### PR TITLE
fix: resolve compiler error for unused dbObj variable in event hooks

### DIFF
--- a/entx/annotation.go
+++ b/entx/annotation.go
@@ -14,6 +14,10 @@
 
 package entx
 
+import (
+	"entgo.io/ent/schema"
+)
+
 // EventsHookAnnotationName is the value of the annotation when read during ent compilation
 var EventsHookAnnotationName = "INFRA9_EVENTHOOKS"
 
@@ -50,3 +54,5 @@ func EventsHookSubjectName(s string) *EventsHookAnnotation {
 		SubjectName: s,
 	}
 }
+
+var _ schema.Annotation = EventsHookAnnotation{}

--- a/entx/template/event_hooks.tmpl
+++ b/entx/template/event_hooks.tmpl
@@ -162,39 +162,41 @@
 								return nil, fmt.Errorf("object doesn't have an id %s", objID)
 							}
 
-							dbObj, err := m.Client().{{ $node.Name }}.Get(ctx, objID)
-							if err != nil {
-								return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
-							}
+                            {{- if hasNonSensitiveAdditionalSubjects $node }}
+    							dbObj, err := m.Client().{{ $node.Name }}.Get(ctx, objID)
+    							if err != nil {
+    								return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
+    							}
 
-							{{- range $f := $node.Fields }}
-								{{- if not $f.Sensitive }}
-									{{- $annotation := $f.Annotations.INFRA9_EVENTHOOKS }}
-									{{- if or $annotation.AdditionalSubjectRelation $annotation.IsAdditionalSubjectField }}
-										{{- if $f.Optional }}
-											if dbObj.{{ $f.MutationGet }} != gidx.NullPrefixedID {
-												additionalSubjects = append(additionalSubjects, dbObj.{{ $f.MutationGet }})
+    							{{- range $f := $node.Fields }}
+    								{{- if not $f.Sensitive }}
+    									{{- $annotation := $f.Annotations.INFRA9_EVENTHOOKS }}
+    									{{- if or $annotation.AdditionalSubjectRelation $annotation.IsAdditionalSubjectField }}
+    										{{- if $f.Optional }}
+    											if dbObj.{{ $f.MutationGet }} != gidx.NullPrefixedID {
+    												additionalSubjects = append(additionalSubjects, dbObj.{{ $f.MutationGet }})
 
-												{{- if $annotation.AdditionalSubjectRelation }}
-												relationships = append(relationships, &authorization.Relationship{
-													Relation:  "{{ $annotation.AdditionalSubjectRelation }}",
-													SubjectId: dbObj.{{ $f.MutationGet }}.String(),
-												})
-												{{- end }}
-											}
-										{{- else }}
-											additionalSubjects = append(additionalSubjects, dbObj.{{ $f.MutationGet }})
+    												{{- if $annotation.AdditionalSubjectRelation }}
+    												relationships = append(relationships, &authorization.Relationship{
+    													Relation:  "{{ $annotation.AdditionalSubjectRelation }}",
+    													SubjectId: dbObj.{{ $f.MutationGet }}.String(),
+    												})
+    												{{- end }}
+    											}
+    										{{- else }}
+    											additionalSubjects = append(additionalSubjects, dbObj.{{ $f.MutationGet }})
 
-											{{- if $annotation.AdditionalSubjectRelation }}
-											relationships = append(relationships, &authorization.Relationship{
-												Relation:  "{{ $annotation.AdditionalSubjectRelation }}",
-												SubjectId: dbObj.{{ $f.MutationGet }}.String(),
-											})
-											{{- end }}
-										{{- end }}
-									{{ end }}
-								{{ end }}
-							{{ end }}
+    											{{- if $annotation.AdditionalSubjectRelation }}
+    											relationships = append(relationships, &authorization.Relationship{
+    												Relation:  "{{ $annotation.AdditionalSubjectRelation }}",
+    												SubjectId: dbObj.{{ $f.MutationGet }}.String(),
+    											})
+    											{{- end }}
+    										{{- end }}
+    									{{ end }}
+    								{{ end }}
+    							{{ end }}
+                            {{ end }}
 
 						// we have all the info we need, now complete the mutation before we process the event
 							retValue, err := next.Mutate(ctx, m)
@@ -257,42 +259,42 @@
 			ResourceId: resourceID.String(),
 			Relationships: relationships,
 		}
-	
+
 		if _, err := iamruntime.ContextCreateRelationships(ctx, request); err == nil || !errors.Is(err, iamruntime.ErrRuntimeNotFound) {
 			return err
 		}
-	
+
 		eventRelationships := make([]events.AuthRelationshipRelation, len(request.Relationships))
-	
+
 		for i, rel := range request.Relationships {
 			eventRelationships[i] = events.AuthRelationshipRelation{
 				Relation:  rel.Relation,
 				SubjectID: gidx.PrefixedID(rel.SubjectId),
 			}
 		}
-	
+
 		return permissions.CreateAuthRelationships(ctx, resourceType, gidx.PrefixedID(request.ResourceId), eventRelationships...)
 	}
-	
+
 	func deleteAuthRelationships(ctx context.Context, resourceType string, resourceID gidx.PrefixedID, relationships ...*authorization.Relationship) error {
 		request := &authorization.DeleteRelationshipsRequest{
 			ResourceId: resourceID.String(),
 			Relationships: relationships,
 		}
-	
+
 		if _, err := iamruntime.ContextDeleteRelationships(ctx, request); err == nil || !errors.Is(err, iamruntime.ErrRuntimeNotFound) {
 			return err
 		}
-	
+
 		eventRelationships := make([]events.AuthRelationshipRelation, len(request.Relationships))
-	
+
 		for i, rel := range request.Relationships {
 			eventRelationships[i] = events.AuthRelationshipRelation{
 				Relation:  rel.Relation,
 				SubjectID: gidx.PrefixedID(rel.SubjectId),
 			}
 		}
-	
+
 		return permissions.DeleteAuthRelationships(ctx, resourceType, gidx.PrefixedID(request.ResourceId), eventRelationships...)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect


### PR DESCRIPTION
The `dbObj` in the deletion event hook is only needed when there are additional
subject annotations on non-sensitive fields or relations, so I created a template
function to check that condition and wrapped the entire section that processes
those annotations in an `if`.
