### PR TITLE
feat: allow PrefixedID prefix's to be any length

### DIFF
--- a/gidx/id.go
+++ b/gidx/id.go
@@ -27,33 +27,32 @@ import (
 )
 
 const (
-	// PrefixPartLength is the number of characters expected in a prefix
-	PrefixPartLength = 7
 	// IDPartLength is the number of characters passed to nanoid when generating an ID value
 	IDPartLength = 21
+	// PrefixPartMinLength is the minimum required number of characters required for a prefix
+	PrefixPartMinLength = 2
 	// Parts represents how many parts of an ID there are
 	Parts = 2
-	// TotalLength is the length of a idx generated PrefixID
-	TotalLength = PrefixPartLength + IDPartLength + Parts - 1
 	// NullPrefixedID represents a null value PrefixedID
 	NullPrefixedID = PrefixedID("")
 )
 
 // PrefixRegexp is the regular expression used to validate a prefix
-var PrefixRegexp = regexp.MustCompile(`^[a-z0-9]{7}$`)
+var PrefixRegexp = regexp.MustCompile(`^[a-z0-9]{2,}$`)
 
 // PrefixedID represents an ID that is formatted as prefix-id. PrefixedIDs are used
 // to implement the relay spec for graphql, which required all IDs to be globally
 // unique between objects and that you have the ability to resolve an object
-// with only the id. Prefixed IDs make it possible by using a 7 characters long
-// prefix with the first 4 characters representing the application the ID belongs
-// to and the next 3 characters representing the object. This makes it possible
-// to receive an ID and programatically tell you the object type the ID represents.
+// with only the id. Prefixed IDs make it possible by using a prefix representing
+// the object. This makes it possible to receive an ID and programatically tell
+// you the object type the ID represents.
 //
-// Examples scenario: instance-api uses the 4 character prefix of inst and has an
-// object type of instance. The 3 character code for instance is anc, so combined
-// the prefix is instanc, resulting an in instance having an id that looks like
-// instanc-myrandomidvalue.
+// Prefixes can be of any length greater than 2 characters, Infratographer
+// projects use a prefix that follows the pattern of 4 characters representing
+// the application and 3 characters representing the obect type. For example,
+// instance-api uses the 4 character prefix of inst and has an object type of
+// instance. The 3 character code for instance is anc, so combined the prefix is
+// instanc, resulting an in instance having an id that looks like instanc-myrandomidvalue.
 type PrefixedID string
 
 // Prefix will return the Prefix value of an ID
@@ -73,8 +72,8 @@ func MustNewID(prefix string) PrefixedID {
 }
 
 func validPrefix(s string) error {
-	if len(s) != PrefixPartLength {
-		return newErrInvalidID(fmt.Sprintf("expected prefix length is %d, '%s' is %d", PrefixPartLength, s, len(s)))
+	if len(s) <= PrefixPartMinLength {
+		return newErrInvalidID(fmt.Sprintf("expected prefix length is at least %d, '%s' is %d", PrefixPartMinLength, s, len(s)))
 	}
 
 	if !PrefixRegexp.MatchString(s) {

--- a/gidx/id.go
+++ b/gidx/id.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/jaevor/go-nanoid"
 )
 
@@ -135,6 +136,11 @@ func Parse(str string) (PrefixedID, error) {
 
 	if err := validPrefix(prefix); err != nil {
 		return "", err
+	}
+
+	// ensure the string isn't a UUID
+	if _, err := uuid.Parse(str); err == nil {
+		return "", newErrInvalidID("uuids are not valid prefix-ids")
 	}
 
 	return PrefixedID(str), nil

--- a/gidx/id.go
+++ b/gidx/id.go
@@ -50,7 +50,7 @@ var PrefixRegexp = regexp.MustCompile(`^[a-z0-9]{2,}$`)
 //
 // Prefixes can be of any length greater than 2 characters, Infratographer
 // projects use a prefix that follows the pattern of 4 characters representing
-// the application and 3 characters representing the obect type. For example,
+// the application and 3 characters representing the object type. For example,
 // instance-api uses the 4 character prefix of inst and has an object type of
 // instance. The 3 character code for instance is anc, so combined the prefix is
 // instanc, resulting an in instance having an id that looks like instanc-myrandomidvalue.

--- a/gidx/id_test.go
+++ b/gidx/id_test.go
@@ -86,6 +86,7 @@ func TestParsers(t *testing.T) {
 		{name: "valid prefix with any length", id: "myreallylongprefixhere-fm21VlAHHrGf6utn1JsKc"},
 		{name: "valid prefix with a uuid ", id: "testing-" + uuid.New().String()},
 		{name: "valid prefix with a additional separators ", id: "testing-------------------"},
+		{name: "invalid id; don't accept a uuid as a prefixed id", id: uuid.New().String(), errorMsg: "invalid id: uuids are not valid prefix-ids"},
 		{name: "invalid id; no separator", id: "somestringthatisalltogether", errorMsg: "invalid id: expected id format is prefix-id"},
 		{name: "invalid id; 1 trailing separator", id: "somestringthatisalltogether-", errorMsg: "invalid id: expected id format is prefix-id"},
 		{name: "invalid id; 1 leading separator", id: "-strings", errorMsg: "invalid id: expected id format is prefix-id"},

--- a/gidx/id_test.go
+++ b/gidx/id_test.go
@@ -17,6 +17,7 @@ package gidx_test
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -27,8 +28,8 @@ import (
 )
 
 func TestNewID(t *testing.T) {
-	// ensure the prefix length hasn't changed. if it does change these tests may need updated
-	require.Equal(t, 7, gidx.PrefixPartLength)
+	// ensure the minimum prefix length hasn't changed. if it does change these tests may need updated
+	require.Equal(t, 2, gidx.PrefixPartMinLength)
 
 	cases := []struct {
 		name     string
@@ -36,10 +37,10 @@ func TestNewID(t *testing.T) {
 		want     string
 		errorMsg string
 	}{
-		{name: "corrent prefix length", prefix: "testpre", want: "testpre-"},
-		{name: "to lower happens", prefix: "ALLCAPS", want: "allcaps-"},
-		{name: "prefix length too short", prefix: "short", errorMsg: "invalid id: expected prefix length is 7"},
-		{name: "prefix length too long", prefix: "notthatshort", errorMsg: "invalid id: expected prefix length is 7"},
+		{name: "corrent prefix length", prefix: "testpre", want: "testpre"},
+		{name: "to lower happens", prefix: "ALLCAPS", want: "allcaps"},
+		{name: "prefix length can be any length", prefix: "myreallylongprefix", want: "myreallylongprefix"},
+		{name: "prefix length too short", prefix: "a", errorMsg: "invalid id: expected prefix length is at least 2"},
 		{name: "prefix with unicode", prefix: "👹bad", errorMsg: "invalid id: expected prefix must match"},
 	}
 
@@ -53,8 +54,9 @@ func TestNewID(t *testing.T) {
 				assert.NoError(t, err)
 				assert.NotNil(t, id)
 				assert.IsType(t, gidx.PrefixedID(""), id)
-				assert.Equal(t, tt.want, id.String()[0:8])
-				assert.Len(t, id.String(), gidx.PrefixPartLength+1+gidx.IDPartLength)
+				assert.Equal(t, tt.want, strings.Split(id.String(), "-")[0])
+				assert.GreaterOrEqual(t, len(id.String()), gidx.PrefixPartMinLength+1+gidx.IDPartLength)
+				assert.Len(t, id.String(), len(tt.prefix)+1+gidx.IDPartLength)
 			}
 		})
 	}
@@ -81,13 +83,13 @@ func TestParsers(t *testing.T) {
 		{name: "valid id: null id should be valid", id: ""},
 		{name: "valid id", id: string(gidx.MustNewID("testing"))},
 		{name: "valid prefix with any length id", id: "testing-any_random#string@i*want(to-put-in-here-of-any-length"},
+		{name: "valid prefix with any length", id: "myreallylongprefixhere-fm21VlAHHrGf6utn1JsKc"},
 		{name: "valid prefix with a uuid ", id: "testing-" + uuid.New().String()},
 		{name: "valid prefix with a additional separators ", id: "testing-------------------"},
 		{name: "invalid id; no separator", id: "somestringthatisalltogether", errorMsg: "invalid id: expected id format is prefix-id"},
 		{name: "invalid id; 1 trailing separator", id: "somestringthatisalltogether-", errorMsg: "invalid id: expected id format is prefix-id"},
 		{name: "invalid id; 1 leading separator", id: "-strings", errorMsg: "invalid id: expected id format is prefix-id"},
-		{name: "invalid id; prefix length too short", id: "short-fm21VlAHHrGf6utn1JsKc", errorMsg: "invalid id: expected prefix length is 7"},
-		{name: "invalid id; prefix length too long", id: "notthatshort-fm21VlAHHrGf6utn1JsKc", errorMsg: "invalid id: expected prefix length is 7"},
+		{name: "invalid id; prefix length too short", id: "a-fm21VlAHHrGf6utn1JsKc", errorMsg: "invalid id: expected prefix length is at least 2"},
 		{name: "invalid id; unicode prefix bad", id: "👹bad-fm21VlAHHrGf6utn1JsKc", errorMsg: "invalid id: expected prefix must match"},
 	}
 


### PR DESCRIPTION
This PR updates prefixed id's to allow them to have any prefix of at least 2 characters. This is fully backwards compatible and doesn't change anything about how infratographer uses prefix ids but allows other users to have prefixes of any length. 