### PR TITLE
feat: add better json support to change events and the ability to include a json diff

### DIFF
--- a/entx/annotation.go
+++ b/entx/annotation.go
@@ -27,6 +27,8 @@ type EventsHookAnnotation struct {
 	SubjectName               string
 	AdditionalSubjectRelation string
 	IsAdditionalSubjectField  bool
+	IsJSONField               bool
+	IncludeJSONDiff           bool
 }
 
 // Name implements the ent Annotation interface.
@@ -52,6 +54,28 @@ func EventsHookAdditionalSubjectField() *EventsHookAnnotation {
 func EventsHookSubjectName(s string) *EventsHookAnnotation {
 	return &EventsHookAnnotation{
 		SubjectName: s,
+	}
+}
+
+// EventsHookJSONField marks this ent field as a field containing JSON to convert the []byte json.RawMessage to a string in the change event
+func EventsHookJSONField() *EventsHookAnnotation {
+	return &EventsHookAnnotation{
+		IsJSONField: true,
+	}
+}
+
+// EventsHookIncludeJSONDiff marks this ent field as a field containing JSON and to calculate a json diff and add it to the additional data of the change event
+func EventsHookIncludeJSONDiff() *EventsHookAnnotation {
+	return &EventsHookAnnotation{
+		IncludeJSONDiff: true,
+	}
+}
+
+// EventsHookJSONFieldWithDiff enabled both JSONField and JSONDiff
+func EventsHookJSONFieldWithDiff() *EventsHookAnnotation {
+	return &EventsHookAnnotation{
+		IsJSONField:     true,
+		IncludeJSONDiff: true,
 	}
 }
 

--- a/entx/template/event_hooks.tmpl
+++ b/entx/template/event_hooks.tmpl
@@ -10,6 +10,7 @@
 	import (
 		"github.com/metal-toolbox/iam-runtime/pkg/iam/runtime/authorization"
 		"github.com/metal-toolbox/iam-runtime-contrib/iamruntime"
+		"github.com/nsf/jsondiff"
 		"go.infratographer.com/permissions-api/pkg/permissions"
 	)
 
@@ -31,6 +32,7 @@
 							}
 
 							changeset := []events.FieldChange{}
+							additionalData := map[string]interface{}{}
 
 							{{- range $f := $node.Fields }}
 								{{- if $f.Sensitive }}
@@ -90,6 +92,8 @@
 												{{ $currentValue }} = {{ $f.Name }}.Format(time.RFC3339)
 											{{- else if $f.HasValueScanner }}
 												{{ $currentValue }} = {{ $f.Name }}.Value()
+											{{- else if $annotation.IsJSONField }}
+												{{ $currentValue }} = string({{ $f.Name }})
 											{{- else }}
 												{{ $currentValue }} = fmt.Sprintf("%s", fmt.Sprint({{ $f.Name }}))
 											{{- end }}
@@ -105,8 +109,18 @@
 													{{ $prevVar }} = ov.Format(time.RFC3339)
 													{{- else if $f.HasValueScanner }}
 													{{ $prevVar }} = ov.Value()
+													{{- else if $annotation.IsJSONField }}
+														{{ $prevVar }} = string(ov)
 													{{- else }}
 													{{ $prevVar }} = fmt.Sprintf("%s", fmt.Sprint(ov))
+													{{- end }}
+
+													{{- if $annotation.IncludeJSONDiff }}
+														opts := jsondiff.DefaultConsoleOptions()
+														opts.SkipMatches = true
+
+														_, diff := jsondiff.Compare(ov, {{ $f.Name }}, &opts)
+														additionalData["{{ $f.Name }}-json-diff"] = diff
 													{{- end }}
 												}
 											}
@@ -127,6 +141,10 @@
 							AdditionalSubjectIDs: additionalSubjects,
 							Timestamp:            time.Now().UTC(),
 							FieldChanges:         changeset,
+						}
+
+						if len(additionalData) != 0 {
+							msg.additionalData = additionalData
 						}
 
 						// complete the mutation before we process the event


### PR DESCRIPTION
Currently json.RawMessage fields result in a []byte being placed into the field for the changes. This adds code to convert that to a string instead. I made it optional to not break backwards compatibility. I also added the ability to add include a JSON diff of the previous and current values as additional data. Here is a diff against metadata-api with the `entx.EventsHookJSONFieldWithDiff()` annotation added to Status.

```
@@ -616,6 +632,7 @@ func StatusHooks() []ent.Hook {
                                        }
 
                                        changeset := []events.FieldChange{}
+                                       additionalData := map[string]interface{}{}
                                        cv_created_at := ""
                                        created_at, ok := m.CreatedAt()
 
@@ -730,14 +747,19 @@ func StatusHooks() []ent.Hook {
                                        data, ok := m.Data()
 
                                        if ok {
-                                               cv_data = fmt.Sprintf("%s", fmt.Sprint(data))
+                                               cv_data = string(data)
                                                pv_data := ""
                                                if !m.Op().Is(ent.OpCreate) {
                                                        ov, err := m.OldData(ctx)
                                                        if err != nil {
                                                                pv_data = "<unknown>"
                                                        } else {
-                                                               pv_data = fmt.Sprintf("%s", fmt.Sprint(ov))
+                                                               pv_data = string(ov)
+                                                               opts := jsondiff.DefaultConsoleOptions()
+                                                               opts.SkipMatches = true
+
+                                                               _, diff := jsondiff.Compare(ov, data, &opts)
+                                                               additionalData["data-json-diff"] = diff
                                                        }
                                                }
 
@@ -756,6 +778,10 @@ func StatusHooks() []ent.Hook {
                                                FieldChanges:         changeset,
                                        }
 
+                                       if len(additionalData) != 0 {
+                                               msg.additionalData = additionalData
+                                       }
+
                                        // complete the mutation before we process the event
                                        retValue, err := next.Mutate(ctx, m)
                                        if err != nil {
```