### PR TITLE
fix: don't send change messages when the old field that changed was the updated_at timestamp, that's not an actual change

### DIFF
--- a/entx/template/event_hooks.tmpl
+++ b/entx/template/event_hooks.tmpl
@@ -159,6 +159,11 @@
 							}
 						}
 
+						// don't send a change message if the only thing that changed was the updated_at timestamp, that's not a real change
+						if len(msg.FieldChanges) == 1 && msg.FieldChanges[0].Field == "updated_at" {
+							return retValue, nil
+						}
+
 						if _, err := m.EventsPublisher.PublishChange(ctx, "{{ $nodeAnnotation.SubjectName }}", msg); err != nil {
 							return nil, fmt.Errorf("failed to publish change: %w", err)
 						}


### PR DESCRIPTION
This code updates the event hooks to not send change messages when the only field that changed is the updated_at field. This shouldn't be something that happens often but can happen in metadata-api especially. 