### PR TITLE
chore: switch over to wsl_v5 and fix linting errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,12 @@ linters:
     - noctx
     - revive
     - whitespace
-    - wsl
+    - wsl_v5
+  settings:
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
   exclusions:
     generated: lax
 formatters:

--- a/crdbx/crdbx.go
+++ b/crdbx/crdbx.go
@@ -15,6 +15,7 @@
 package crdbx
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -45,7 +46,7 @@ func NewDB(cfg Config, tracing bool) (*sql.DB, error) {
 		return nil, fmt.Errorf("failed connecting to database: %w", err)
 	}
 
-	if err := db.Ping(); err != nil {
+	if err := db.PingContext(context.TODO()); err != nil {
 		return nil, fmt.Errorf("failed verifying database connection: %w", err)
 	}
 

--- a/echojwtx/handler_test.go
+++ b/echojwtx/handler_test.go
@@ -127,7 +127,9 @@ func TestAudienceValidation(t *testing.T) {
 			require.NoError(t, err, "no error expected for NewAuth")
 
 			gotUserTokenCh := make(chan *jwt.Token, 1)
+
 			gotActorCh := make(chan string, 1)
+
 			gotActorCtxCh := make(chan string, 1)
 
 			e := echo.New()
@@ -140,7 +142,9 @@ func TestAudienceValidation(t *testing.T) {
 				actorCtx, _ := c.Request().Context().Value(echojwtx.ActorCtxKey).(string)
 
 				gotUserTokenCh <- token
+
 				gotActorCh <- actor
+
 				gotActorCtxCh <- actorCtx
 
 				return nil

--- a/echox/echo_test.go
+++ b/echox/echo_test.go
@@ -644,6 +644,7 @@ func TestServe(t *testing.T) {
 			if cancel == nil {
 				// Ask for SIGTERM (ensures we don't exit when we trigger killing ourself)
 				c := make(chan os.Signal, 1)
+
 				signal.Notify(c, syscall.SIGTERM)
 				defer signal.Stop(c)
 

--- a/echox/echozap/middleware.go
+++ b/echox/echozap/middleware.go
@@ -116,7 +116,6 @@ func (config MiddlewareConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 
 			if err != nil {
 				fields = append(fields, zap.Error(err))
-
 				if httpErr, ok := err.(*echo.HTTPError); ok {
 					fields = append(fields,
 						zap.Int("error_code", httpErr.Code),

--- a/echox/echozap/middleware_test.go
+++ b/echox/echozap/middleware_test.go
@@ -270,7 +270,6 @@ func TestToMiddleware(t *testing.T) {
 			}
 
 			mdw, err := tc.config.ToMiddleware()
-
 			if tc.expectConfigError != nil {
 				require.Error(t, err, "expected error to be returned")
 

--- a/entx/json_test.go
+++ b/entx/json_test.go
@@ -48,7 +48,6 @@ func TestUnmarshalRawMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := UnmarshalRawMessage(tt.arg)
-
 			if (err != nil) != tt.wantErr {
 				t.Errorf("UnmarshalRawMessage() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/events/message.go
+++ b/events/message.go
@@ -397,6 +397,7 @@ func (m AuthRelationshipResponse) Validate() error {
 // UnmarshalChangeMessage returns a ChangeMessage from a json []byte.
 func UnmarshalChangeMessage(b []byte) (ChangeMessage, error) {
 	var c ChangeMessage
+
 	err := json.Unmarshal(b, &c)
 
 	return c, err
@@ -405,6 +406,7 @@ func UnmarshalChangeMessage(b []byte) (ChangeMessage, error) {
 // UnmarshalEventMessage returns a EventMessage from a json []byte.
 func UnmarshalEventMessage(b []byte) (EventMessage, error) {
 	var m EventMessage
+
 	err := json.Unmarshal(b, &m)
 
 	return m, err
@@ -413,6 +415,7 @@ func UnmarshalEventMessage(b []byte) (EventMessage, error) {
 // UnmarshalAuthRelationshipRequest returns an AuthRelationshipRequest from a json []byte.
 func UnmarshalAuthRelationshipRequest(b []byte) (AuthRelationshipRequest, error) {
 	var m AuthRelationshipRequest
+
 	err := json.Unmarshal(b, &m)
 
 	return m, err
@@ -421,6 +424,7 @@ func UnmarshalAuthRelationshipRequest(b []byte) (AuthRelationshipRequest, error)
 // UnmarshalAuthRelationshipResponse returns an AuthRelationshipRsponse from a json []byte.
 func UnmarshalAuthRelationshipResponse(b []byte) (AuthRelationshipResponse, error) {
 	var m AuthRelationshipResponse
+
 	err := json.Unmarshal(b, &m)
 
 	return m, err

--- a/otelx/tracing.go
+++ b/otelx/tracing.go
@@ -130,7 +130,6 @@ func NewTracerProviderWithExporter(exporter sdktrace.SpanExporter, appName strin
 			semconv.DeploymentEnvironmentName(tc.Environment),
 		),
 	)
-
 	if err != nil {
 		return nil, &ConfigError{
 			Message: "could not construct otel resource",

--- a/testing/eventtools/nats.go
+++ b/testing/eventtools/nats.go
@@ -91,10 +91,10 @@ func (s *TestNats) WaitForAck(consumer string, timeout time.Duration) error { //
 func (s *TestNats) waitForAck(consumer string, timeout time.Duration) error {
 	// We should only ever receive one Ack, so we close the channel directly if we get one.
 	ackCh := make(chan struct{})
+
 	ackSub, err := s.Conn.Subscribe("$JS.EVENT.METRIC.CONSUMER.ACK.*."+consumer, func(_ *nats.Msg) {
 		close(ackCh)
 	})
-
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,6 @@ func (s *TestNats) waitForAck(consumer string, timeout time.Duration) error {
 			close(nakCh)
 		})
 	})
-
 	if err != nil {
 		return err
 	}
@@ -141,6 +140,7 @@ func (s *TestNats) CaptureMsgAck(consumer string, timeout time.Duration, msgFunc
 	}
 
 	errCh := make(chan error, 1)
+
 	go func() {
 		errCh <- s.waitForAck(consumer, timeout)
 	}()


### PR DESCRIPTION
Renovate PRs are failing to auto merge do to linting errors with the newer version of golangci-lint. This fixes the listing errors and gets everything back to where those PRs can start auto merging again. 